### PR TITLE
Rewrite module to parse arbitrary values if possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # get-cors-origin
 
-get-cors-origin transforms an array of strings into a cors configuration.
+get-cors-origin parses any value into a cors configuration if possible.
 
 ## Status
 
@@ -32,15 +32,20 @@ If you use TypeScript, use the following code instead:
 import { getCorsOrigin } from 'get-cors-origin';
 ```
 
-Then you can call the `getCorsOrigin` function to transform an array of strings into a configuration suitable for the [cors](https://www.npmjs.com/package/cors) module:
+Then you can call the `getCorsOrigin` function to parse any value into a configuration suitable for the [cors](https://www.npmjs.com/package/cors) module if possible:
 
+-   If you provide `false` as parameter, you just get `false` back and cors will be disabled by the middleware.
 -   If you provide a `*` as parameter, you just get `*` back.
 -   If you provide one or more domains as parameters, you get an array of domains back.
 -   If you provide a domain as a string that contains a regular expression, the string is converted to a regular expression.
+-   If you provide anything else, an error will be thrown.
 
 Additionally, any whitespace is removed:
 
 ```javascript
+const corsOrigin = getCorsOrigin(false);
+// => false
+
 const corsOrigin = getCorsOrigin('*');
 // => '*'
 
@@ -75,6 +80,12 @@ const corsOrigin = getCorsOrigin([
 //      'http://www.thenativeweb.io'
 //      /\.thenativeweb\.io$/
 //    ]
+
+const corsOrigin = getCorsOrigin(true);
+// => error
+
+const corsOrigin = getCorsOrigin(123);
+// => error
 ```
 
 ## Running the build

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ import { getCorsOrigin } from 'get-cors-origin';
 Then you can call the `getCorsOrigin` function to parse any value into a configuration suitable for the [cors](https://www.npmjs.com/package/cors) module if possible:
 
 -   If you provide a `*` as parameter, you just get `*` back.
+-   If you provide one or more domains as parameters in an array, you get an array of sanitized domains back.
 -   If you provide a domain as a string that contains a regular expression, the string is converted to a regular expression.
 -   If you provide anything else, an error will be thrown.
 

--- a/README.md
+++ b/README.md
@@ -34,25 +34,15 @@ import { getCorsOrigin } from 'get-cors-origin';
 
 Then you can call the `getCorsOrigin` function to parse any value into a configuration suitable for the [cors](https://www.npmjs.com/package/cors) module if possible:
 
--   If you provide `false` as parameter, you just get `false` back and cors will be disabled by the middleware.
 -   If you provide a `*` as parameter, you just get `*` back.
--   If you provide one or more domains as parameters, you get an array of domains back.
 -   If you provide a domain as a string that contains a regular expression, the string is converted to a regular expression.
 -   If you provide anything else, an error will be thrown.
 
 Additionally, any whitespace is removed:
 
 ```javascript
-const corsOrigin = getCorsOrigin(false);
-// => false
-
 const corsOrigin = getCorsOrigin('*');
 // => '*'
-
-const corsOrigin = getCorsOrigin('http://www.thenativeweb.io');
-// => [
-//      'http://www.thenativeweb.io'
-//    ]
 
 const corsOrigin = getCorsOrigin([
   'http://www.thenativeweb.io',
@@ -82,6 +72,9 @@ const corsOrigin = getCorsOrigin([
 //    ]
 
 const corsOrigin = getCorsOrigin(true);
+// => error
+
+const corsOrigin = getCorsOrigin('http://www.thenativeweb.io');
 // => error
 
 const corsOrigin = getCorsOrigin(123);

--- a/lib/CorsOrigin.ts
+++ b/lib/CorsOrigin.ts
@@ -1,0 +1,1 @@
+export type CorsOrigin = '*' | (string | RegExp)[];

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,9 @@
+import { defekt } from 'defekt';
+
+const errors = defekt({
+  CorsOriginInvalid: {}
+});
+
+export {
+  errors
+};

--- a/lib/getCorsOrigin.ts
+++ b/lib/getCorsOrigin.ts
@@ -8,7 +8,7 @@ const getCorsOrigin = function (value: any): CorsOrigin {
       return value;
     }
 
-    throw new errors.CorsOriginInvalid(`Not a valid cors origin value. Please wrap strings other than '*' in an array.`, { data: value });
+    throw new errors.CorsOriginInvalid(`Not a valid CORS origin value. Please wrap strings other than '*' in an array.`, { data: value });
   }
 
   if (Array.isArray(value)) {
@@ -23,7 +23,7 @@ const getCorsOrigin = function (value: any): CorsOrigin {
     });
   }
 
-  throw new errors.CorsOriginInvalid('Not a valid cors origin value.', { data: value });
+  throw new errors.CorsOriginInvalid('Not a valid CORS origin value.', { data: value });
 };
 
 export { getCorsOrigin };

--- a/lib/getCorsOrigin.ts
+++ b/lib/getCorsOrigin.ts
@@ -1,23 +1,29 @@
+import { CorsOrigin } from './CorsOrigin';
+import { errors } from './errors';
 import { looksLikeARegex } from './looksLikeARegex';
 
-const getCorsOrigin = function (value: string | string[]): string | (string | RegExp)[] {
-  if (value === '*') {
-    return value;
-  }
-
-  const values = Array.isArray(value) ? value : [ value ];
-
-  const origins = values.map((origin): string | RegExp => {
-    const updatedOrigin = origin.trim();
-
-    if (looksLikeARegex(updatedOrigin)) {
-      return new RegExp(updatedOrigin.slice(1, -1), 'u');
+const getCorsOrigin = function (value: any): CorsOrigin {
+  if (typeof value === 'string') {
+    if (value === '*') {
+      return value;
     }
 
-    return updatedOrigin;
-  });
+    throw new errors.CorsOriginInvalid(`Not a valid cors origin value. Please wrap strings other than '*' in an array.`, { data: value });
+  }
 
-  return origins;
+  if (Array.isArray(value)) {
+    return value.map((origin): string | RegExp => {
+      const trimmedOrigin = origin.trim();
+
+      if (looksLikeARegex(trimmedOrigin)) {
+        return new RegExp(trimmedOrigin.slice(1, -1), 'u');
+      }
+
+      return trimmedOrigin;
+    });
+  }
+
+  throw new errors.CorsOriginInvalid('Not a valid cors origin value.', { data: value });
 };
 
 export { getCorsOrigin };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,9 @@
+import { CorsOrigin } from './CorsOrigin';
+import { errors } from './errors';
+import { getCorsOrigin } from './getCorsOrigin';
+
+export {
+  CorsOrigin,
+  errors,
+  getCorsOrigin
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -880,7 +880,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
       "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-      "dev": true,
       "requires": {
         "xregexp": "4.0.0"
       }
@@ -901,7 +900,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/defekt/-/defekt-5.0.0.tgz",
       "integrity": "sha512-A16uAUlfiwlC/xGixS4ebJTqnSEqaBRCKFijeKxW5UYwEoSWzNuaQKa7OWsZ+zzW/I2itiDCl2ZZt4UqHaUQsg==",
-      "dev": true,
       "requires": {
         "humanize-string": "2.1.0"
       }
@@ -1716,7 +1714,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-2.1.0.tgz",
       "integrity": "sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==",
-      "dev": true,
       "requires": {
         "decamelize": "^2.0.0"
       }
@@ -4024,8 +4021,7 @@
     "xregexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-cors-origin",
   "version": "3.0.0",
-  "description": "get-cors-origin transforms an array of strings into a cors configuration.",
+  "description": "get-cors-origin parser any value into a cors configuration if possible.",
   "contributors": [
     {
       "name": "Golo Roden",
@@ -14,11 +14,17 @@
     {
       "name": "Jan-Hendrik Grundhöfer",
       "email": "jan-hendrik.grundhoefer@thenativeweb.io"
+    },
+    {
+      "name": "Hannes Leutloff",
+      "email": "hannes.leutloff@thenativeweb.io"
     }
   ],
   "main": "build/lib/getCorsOrigin.js",
   "types": "build/lib/getCorsOrigin.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "defekt": "5.0.0"
+  },
   "devDependencies": {
     "assertthat": "5.0.2",
     "roboter": "9.2.4"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
       "email": "hannes.leutloff@thenativeweb.io"
     }
   ],
-  "main": "build/lib/getCorsOrigin.js",
-  "types": "build/lib/getCorsOrigin.d.ts",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
   "dependencies": {
     "defekt": "5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-cors-origin",
   "version": "3.0.0",
-  "description": "get-cors-origin parser any value into a cors configuration if possible.",
+  "description": "get-cors-origin parses any value into a cors configuration if possible.",
   "contributors": [
     {
       "name": "Golo Roden",

--- a/test/unit/getCorsOriginTests.ts
+++ b/test/unit/getCorsOriginTests.ts
@@ -1,15 +1,10 @@
 import { assert } from 'assertthat';
+import { CustomError } from 'defekt';
 import { getCorsOrigin } from '../../lib/getCorsOrigin';
 
 suite('getCorsOrigin', (): void => {
-  test('returns * if * is given.', async (): Promise<void> => {
+  test(`returns '*' if '*' is given.`, async (): Promise<void> => {
     assert.that(getCorsOrigin('*')).is.equalTo('*');
-  });
-
-  test('returns an array with one item if a single value is given.', async (): Promise<void> => {
-    assert.that(getCorsOrigin('http://www.thenativeweb.io')).is.equalTo([
-      'http://www.thenativeweb.io'
-    ]);
   });
 
   test('returns an array with multiple items if multiple values are given.', async (): Promise<void> => {
@@ -31,5 +26,49 @@ suite('getCorsOrigin', (): void => {
       'http://www.thenativeweb.io',
       /\.thenativeweb\.io$/u
     ]);
+  });
+
+  test(`throws an error if a string other than '*' is given.`, async (): Promise<void> => {
+    assert.that((): any => getCorsOrigin('http://www.thenativeweb.io')).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        ex.message === `Not a valid cors origin value. Please wrap strings other than '*' in an array.` &&
+        (ex as CustomError).data === 'http://www.thenativeweb.io'
+    );
+  });
+
+  test('throws an error if a boolean is given.', async (): Promise<void> => {
+    assert.that((): any => getCorsOrigin(false)).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        ex.message === `Not a valid cors origin value.` &&
+        (ex as CustomError).data === false
+    );
+    assert.that((): any => getCorsOrigin(true)).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        ex.message === `Not a valid cors origin value.` &&
+        (ex as CustomError).data === true
+    );
+  });
+
+  test('throws an error if a number is given.', async (): Promise<void> => {
+    assert.that((): any => getCorsOrigin(1337)).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        ex.message === `Not a valid cors origin value.` &&
+        (ex as CustomError).data === 1337
+    );
+  });
+
+  test('throws an error if an object is given.', async (): Promise<void> => {
+    const objectCorsOrigin = { origin: 'http://www.thenativeweb.io' };
+
+    assert.that((): any => getCorsOrigin(objectCorsOrigin)).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        ex.message === `Not a valid cors origin value.` &&
+        (ex as CustomError).data === objectCorsOrigin
+    );
   });
 });

--- a/test/unit/getCorsOriginTests.ts
+++ b/test/unit/getCorsOriginTests.ts
@@ -32,7 +32,7 @@ suite('getCorsOrigin', (): void => {
     assert.that((): any => getCorsOrigin('http://www.thenativeweb.io')).is.throwing(
       (ex): boolean =>
         (ex as CustomError).code === 'ECORSORIGININVALID' &&
-        ex.message === `Not a valid cors origin value. Please wrap strings other than '*' in an array.` &&
+        ex.message === `Not a valid CORS origin value. Please wrap strings other than '*' in an array.` &&
         (ex as CustomError).data === 'http://www.thenativeweb.io'
     );
   });
@@ -41,13 +41,13 @@ suite('getCorsOrigin', (): void => {
     assert.that((): any => getCorsOrigin(false)).is.throwing(
       (ex): boolean =>
         (ex as CustomError).code === 'ECORSORIGININVALID' &&
-        ex.message === `Not a valid cors origin value.` &&
+        ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === false
     );
     assert.that((): any => getCorsOrigin(true)).is.throwing(
       (ex): boolean =>
         (ex as CustomError).code === 'ECORSORIGININVALID' &&
-        ex.message === `Not a valid cors origin value.` &&
+        ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === true
     );
   });
@@ -56,7 +56,7 @@ suite('getCorsOrigin', (): void => {
     assert.that((): any => getCorsOrigin(1337)).is.throwing(
       (ex): boolean =>
         (ex as CustomError).code === 'ECORSORIGININVALID' &&
-        ex.message === `Not a valid cors origin value.` &&
+        ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === 1337
     );
   });
@@ -67,7 +67,7 @@ suite('getCorsOrigin', (): void => {
     assert.that((): any => getCorsOrigin(objectCorsOrigin)).is.throwing(
       (ex): boolean =>
         (ex as CustomError).code === 'ECORSORIGININVALID' &&
-        ex.message === `Not a valid cors origin value.` &&
+        ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === objectCorsOrigin
     );
   });


### PR DESCRIPTION
Contains breaking changes, since now arbitrary values are accepted as input and invalid values will cause an error.

Now only accepts inputs matching the new type `type CorsOrigin = '*' | (string | RegExp)[]` as valid.