### PR TITLE
fix: update defekt

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,7 +1,7 @@
 import { defekt } from 'defekt';
 
-const errors = defekt({
-  CorsOriginInvalid: {}
-});
+class CorsOriginInvalid extends defekt({ code: 'CorsOriginInvalid' }) { }
 
-export { errors };
+export {
+  CorsOriginInvalid
+};

--- a/lib/getCorsOrigin.ts
+++ b/lib/getCorsOrigin.ts
@@ -1,6 +1,6 @@
 import { CorsOrigin } from './CorsOrigin';
-import { errors } from './errors';
 import { looksLikeRegex } from './looksLikeRegex';
+import * as errors from './errors';
 
 const getCorsOrigin = function (value: any): CorsOrigin {
   if (typeof value === 'string') {
@@ -8,7 +8,7 @@ const getCorsOrigin = function (value: any): CorsOrigin {
       return value;
     }
 
-    throw new errors.CorsOriginInvalid(`Not a valid CORS origin value. Please wrap strings other than '*' in an array.`, { data: value });
+    throw new errors.CorsOriginInvalid({ message: `Not a valid CORS origin value. Please wrap strings other than '*' in an array.`, data: value });
   }
 
   if (Array.isArray(value)) {
@@ -23,7 +23,7 @@ const getCorsOrigin = function (value: any): CorsOrigin {
     });
   }
 
-  throw new errors.CorsOriginInvalid('Not a valid CORS origin value.', { data: value });
+  throw new errors.CorsOriginInvalid({ message: 'Not a valid CORS origin value.', data: value });
 };
 
 export { getCorsOrigin };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { CorsOrigin } from './CorsOrigin';
-import { errors } from './errors';
 import { getCorsOrigin } from './getCorsOrigin';
+import * as errors from './errors';
 
 export { CorsOrigin, errors, getCorsOrigin };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,9 +2078,9 @@
       }
     },
     "defekt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
-      "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/defekt/-/defekt-7.0.4.tgz",
+      "integrity": "sha512-6+70JzdjQigN9WHFWrWgQGcbpn0YsTUj7moJBBX+3gMeWUnavnK0aOTD5IMOkPAy+emPETtn1//3WyT5aO4XzQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8830,6 +8830,12 @@
         "typescript": "4.2.3"
       },
       "dependencies": {
+        "defekt": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
+          "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA==",
+          "dev": true
+        },
         "globby": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",
   "dependencies": {
-    "defekt": "6.0.2"
+    "defekt": "7.0.4"
   },
   "devDependencies": {
     "assertthat": "5.2.6",

--- a/test/unit/getCorsOriginTests.ts
+++ b/test/unit/getCorsOriginTests.ts
@@ -1,6 +1,7 @@
 import { assert } from 'assertthat';
 import { CustomError } from 'defekt';
 import { getCorsOrigin } from '../../lib/getCorsOrigin';
+import * as errors from '../../lib/errors';
 
 suite('getCorsOrigin', (): void => {
   test(`returns '*' if '*' is given.`, async (): Promise<void> => {
@@ -31,7 +32,7 @@ suite('getCorsOrigin', (): void => {
   test(`throws an error if a string other than '*' is given.`, async (): Promise<void> => {
     assert.that((): any => getCorsOrigin('http://www.thenativeweb.io')).is.throwing(
       (ex): boolean =>
-        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        (ex as CustomError).code === errors.CorsOriginInvalid.code &&
         ex.message === `Not a valid CORS origin value. Please wrap strings other than '*' in an array.` &&
         (ex as CustomError).data === 'http://www.thenativeweb.io'
     );
@@ -40,13 +41,13 @@ suite('getCorsOrigin', (): void => {
   test('throws an error if a boolean is given.', async (): Promise<void> => {
     assert.that((): any => getCorsOrigin(false)).is.throwing(
       (ex): boolean =>
-        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        (ex as CustomError).code === errors.CorsOriginInvalid.code &&
         ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === false
     );
     assert.that((): any => getCorsOrigin(true)).is.throwing(
       (ex): boolean =>
-        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        (ex as CustomError).code === errors.CorsOriginInvalid.code &&
         ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === true
     );
@@ -55,7 +56,7 @@ suite('getCorsOrigin', (): void => {
   test('throws an error if a number is given.', async (): Promise<void> => {
     assert.that((): any => getCorsOrigin(1_337)).is.throwing(
       (ex): boolean =>
-        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        (ex as CustomError).code === errors.CorsOriginInvalid.code &&
         ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === 1_337
     );
@@ -66,7 +67,7 @@ suite('getCorsOrigin', (): void => {
 
     assert.that((): any => getCorsOrigin(objectCorsOrigin)).is.throwing(
       (ex): boolean =>
-        (ex as CustomError).code === 'ECORSORIGININVALID' &&
+        (ex as CustomError).code === errors.CorsOriginInvalid.code &&
         ex.message === 'Not a valid CORS origin value.' &&
         (ex as CustomError).data === objectCorsOrigin
     );


### PR DESCRIPTION
BREAKING CHANGE

The errors thrown by the library have changed, if you relied on their error codes before, you have to use the exported errors.